### PR TITLE
Adding version info and checks

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -33,8 +33,26 @@ def add_sources(sources, directory):
             sources.append(directory + '/' + file)
 
 # have to figure out what to do here....
-#if platform == "android":
-#    if target == "debug":
+if platform == "android":
+    
+    libPaths = [
+    os.getenv('NDK_ROOT') + '/build/cxx-stl/gnu-libstdc++/lib',
+    '/anotherLibPath',
+    '/and/yet/another'
+    ]
+
+    includePaths = [
+        '/pathToNDK/build/cxx-stl/gnu-libstdc++/include',
+        '/anotherIncludePath',
+        '/and/yet/another/include'
+    ]
+
+    env.Append(LIBPATH = libPaths, CPPPATH = includePaths)
+    env.Library(target='yourTarget', source = 'sourceFile.cc')
+    env.Program(target='yourBinary', source = 'yourSource')
+    
+    if target == "debug":
+        env['LINKCOM'] = '$LINK -o $TARGET $__RPATH $SOURCES $LINKFLAGS $_LIBDIRFLAGS $_LIBFLAGS'
 #        env.Append(CCFLAGS = ['-EHsc', '-D_DEBUG', '/MTd'])
 #    else:
 #        env.Append(CCFLAGS = ['-O2', '-EHsc', '-DNDEBUG', '/MT'])

--- a/SConstruct
+++ b/SConstruct
@@ -43,9 +43,9 @@ def add_sources(sources, directory):
 env.Append(CPPPATH=[gearvr_path + 'VrApi/Include'])
 target_path = 'demo/bin/arm64/godot_gearvr'
 if bits == '64':
-    env.Append(LIBPATH=[oculus_path + 'VrApi/Libs/Android/arm64-v8a/' + target])
+    env.Append(LIBPATH=[gearvr_path + 'VrApi/Libs/Android/arm64-v8a/' + target])
 else:
-    env.Append(LIBPATH=[oculus_path + 'VrApi/Libs/Android/armeabi-v7a/' + target])
+    env.Append(LIBPATH=[gearvr_path + 'VrApi/Libs/Android/armeabi-v7a/' + target])
     target_path = 'demo/bin/arm32/godot_gearvr'
 
 env.Append(LIBS=['libvrapi'])
@@ -54,7 +54,10 @@ env.Append(LIBS=['libvrapi'])
 env.Append(CPPPATH=['.', godot_headers_path])
 
 sources = []
-add_sources(sources, "src")
+if os.path.isdir('src'):
+    add_sources(sources, "src")
+else:
+    add_sources(sources, "jni")
 # sources.append(godot_glad_path + "/glad.c")
 
 library = env.SharedLibrary(target=target_path, source=sources)

--- a/SConstruct
+++ b/SConstruct
@@ -33,26 +33,8 @@ def add_sources(sources, directory):
             sources.append(directory + '/' + file)
 
 # have to figure out what to do here....
-if platform == "android":
-    
-    libPaths = [
-    os.getenv('NDK_ROOT') + '/build/cxx-stl/gnu-libstdc++/lib',
-    '/anotherLibPath',
-    '/and/yet/another'
-    ]
-
-    includePaths = [
-        '/pathToNDK/build/cxx-stl/gnu-libstdc++/include',
-        '/anotherIncludePath',
-        '/and/yet/another/include'
-    ]
-
-    env.Append(LIBPATH = libPaths, CPPPATH = includePaths)
-    env.Library(target='yourTarget', source = 'sourceFile.cc')
-    env.Program(target='yourBinary', source = 'yourSource')
-    
-    if target == "debug":
-        env['LINKCOM'] = '$LINK -o $TARGET $__RPATH $SOURCES $LINKFLAGS $_LIBDIRFLAGS $_LIBFLAGS'
+#if platform == "android":
+#    if target == "debug":
 #        env.Append(CCFLAGS = ['-EHsc', '-D_DEBUG', '/MTd'])
 #    else:
 #        env.Append(CCFLAGS = ['-O2', '-EHsc', '-DNDEBUG', '/MT'])
@@ -61,9 +43,9 @@ if platform == "android":
 env.Append(CPPPATH=[gearvr_path + 'VrApi/Include'])
 target_path = 'demo/bin/arm64/godot_gearvr'
 if bits == '64':
-    env.Append(LIBPATH=[gearvr_path + 'VrApi/Libs/Android/arm64-v8a/' + target])
+    env.Append(LIBPATH=[oculus_path + 'VrApi/Libs/Android/arm64-v8a/' + target])
 else:
-    env.Append(LIBPATH=[gearvr_path + 'VrApi/Libs/Android/armeabi-v7a/' + target])
+    env.Append(LIBPATH=[oculus_path + 'VrApi/Libs/Android/armeabi-v7a/' + target])
     target_path = 'demo/bin/arm32/godot_gearvr'
 
 env.Append(LIBS=['libvrapi'])
@@ -72,10 +54,7 @@ env.Append(LIBS=['libvrapi'])
 env.Append(CPPPATH=['.', godot_headers_path])
 
 sources = []
-if os.path.isdir('src'):
-    add_sources(sources, "src")
-else:
-    add_sources(sources, "jni")
+add_sources(sources, "src")
 # sources.append(godot_glad_path + "/glad.c")
 
 library = env.SharedLibrary(target=target_path, source=sources)

--- a/jni/ARVRInterface.cpp
+++ b/jni/ARVRInterface.cpp
@@ -316,6 +316,7 @@ void godot_arvr_destructor(void *p_data) {
 };
 
 const godot_arvr_interface_gdnative interface_struct = {
+    GODOTVR_API_MAJOR, GODOTVR_API_MINOR,
 	godot_arvr_constructor,
 	godot_arvr_destructor,
 	godot_arvr_get_name,

--- a/jni/GodotCalls.cpp
+++ b/jni/GodotCalls.cpp
@@ -12,6 +12,43 @@ const godot_gdnative_core_api_struct *api = NULL;
 const godot_gdnative_ext_arvr_api_struct *arvr_api = NULL;
 const godot_gdnative_ext_nativescript_api_struct *nativescript_api = NULL;
 
+void GDN_EXPORT godot_gearvr_gdnative_init(godot_gdnative_init_options *p_options) {
+	// get our main API struct
+	api = p_options->api_struct;
+
+	// now find our arvr extension
+	for (int i = 0; i < api->num_extensions; i++) {
+		// todo: add version checks
+		switch (api->extensions[i]->type) {
+			case GDNATIVE_EXT_ARVR: {
+				if (api->extensions[i]->version.major > 1 || (api->extensions[i]->version.major == 1 && api->extensions[i]->version.minor >= 1)) {
+					arvr_api = (godot_gdnative_ext_arvr_api_struct *)api->extensions[i];
+				} else {
+					printf("ARVR API version %i.%i isn't supported, need version 1.1 or higher\n", api->extensions[i]->version.major, api->extensions[i]->version.minor);
+				}
+			}; break;
+			case GDNATIVE_EXT_NATIVESCRIPT: {
+				if (api->extensions[i]->version.major > 1 || (api->extensions[i]->version.major == 1 && api->extensions[i]->version.minor >= 0)) {
+					nativescript_api = (godot_gdnative_ext_nativescript_api_struct *)api->extensions[i];
+				} else {
+					printf("Native script API version %i.%i isn't supported, need version 1.1 or higher\n", api->extensions[i]->version.major, api->extensions[i]->version.minor);
+				}
+			}; break;
+			default: break;
+		};
+	};
+
+//	if (!gladLoadGL()) {
+//		printf("Error initializing GLAD\n");
+//	}
+}
+
+void GDN_EXPORT godot_gearvr_gdnative_terminate(godot_gdnative_terminate_options *p_options) {
+	api = NULL;
+    nativescript_api = NULL;
+    arvr_api = NULL;
+}
+
 int64_t ___godot_icall_int(godot_method_bind *mb, godot_object *inst) {
 	int64_t ret;
 	const void *args[1] = {

--- a/jni/GodotCalls.h
+++ b/jni/GodotCalls.h
@@ -53,6 +53,9 @@ extern const godot_gdnative_ext_nativescript_api_struct *nativescript_api;
 extern "C" {
 #endif
 
+void GDN_EXPORT godot_gearvr_gdnative_init(godot_gdnative_init_options *p_options);
+void GDN_EXPORT godot_gearvr_gdnative_terminate(godot_gdnative_terminate_options *p_options);
+    
 int64_t ___godot_icall_int(godot_method_bind *mb, godot_object *inst);
 void ___godot_icall_void_int(godot_method_bind *mb, godot_object *inst, const int arg0);
 void ___godot_icall_void_int_Array_Array_int(godot_method_bind *mb, godot_object *inst, const int arg0, const godot_array& arg1, const godot_array& arg2, const int arg3);

--- a/jni/godot_gearvr.cpp
+++ b/jni/godot_gearvr.cpp
@@ -10,38 +10,10 @@
 
 #include "godot_gearvr.h"
 
-////////////////////////////////////////////////////////////////////////
-// gdnative init
-
-void GDN_EXPORT godot_gearvr_gdnative_init(godot_gdnative_init_options *p_options) {
-	// get our main API struct
-	api = p_options->api_struct;
-
-	// now find our arvr extension
-	for (int i = 0; i < api->num_extensions; i++) {
-		// todo: add version checks
-		switch (api->extensions[i]->type) {
-			case GDNATIVE_EXT_ARVR: {
-				arvr_api = (godot_gdnative_ext_arvr_api_struct *)api->extensions[i];
-			}; break;
-			case GDNATIVE_EXT_NATIVESCRIPT: {
-				nativescript_api = (godot_gdnative_ext_nativescript_api_struct *)api->extensions[i];
-			}; break;
-			default: break;
-		};
-	};
-
-//	if (!gladLoadGL()) {
-//		printf("Error initializing GLAD\n");
-//	}
-}
-
-void GDN_EXPORT godot_gearvr_gdnative_terminate(godot_gdnative_terminate_options *p_options) {
-	api = NULL;
-}
-
 void GDN_EXPORT godot_gearvr_gdnative_singleton() {
-	arvr_api->godot_arvr_register_interface(&interface_struct);
+    if (arvr_api != NULL) {
+        arvr_api->godot_arvr_register_interface(&interface_struct);
+    }
 }
 
 void GDN_EXPORT godot_gearvr_nativescript_init(void *p_handle) {

--- a/jni/godot_gearvr.h
+++ b/jni/godot_gearvr.h
@@ -16,8 +16,6 @@
 extern "C" {
 #endif
 
-void GDN_EXPORT godot_gearvr_gdnative_init(godot_gdnative_init_options *p_options);
-void GDN_EXPORT godot_gearvr_gdnative_terminate(godot_gdnative_terminate_options *p_options);
 void GDN_EXPORT godot_gearvr_gdnative_singleton();
 void GDN_EXPORT godot_gearvr_nativescript_init(void *p_handle);
 


### PR DESCRIPTION
This patch fixes the break for 3.0 due to the version field introduced in 3.1.

Note when compiling you must specify the path to your Godot master as godot_headers still contains the 3.0 headers!