### PR TITLE
Changes to build and new API

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,15 @@ The rest of this project is released under a MIT license.
 Compiling
 ---------
 In order to compile this plugin you first need to download the GearVR SDK from the Oculus developer website.
-You will also need the Android NDK(Make sure it's in your PATH variable) and JDK.
+You will also need the Android NDK (Make sure it's in your PATH variable) and JDK.
 
 After cloning this repository make sure to initialise the submodules with `git submodule init`
 When you've pulled a newer version make sure to run `git submodule update`
 
-Next, modify the jni/Android.mk by adding the respective paths. Alternatively, you can add them to path and call using $(Var_Name).
+For now you will need to edit the `jni/android.mk` file to correct some paths. Still working on making that switchable
 
-Then run `ndk-build NDK_LIBS_OUT=./demo/addons/godot_gearvr/bin`
+Now run:
+```
+cd jni
+ndk-build
+```

--- a/jni/ARVRInterface.cpp
+++ b/jni/ARVRInterface.cpp
@@ -178,10 +178,10 @@ godot_bool godot_arvr_initialize(void *p_data) {
       abort();
     }
 
-    arvr_data->java.ActivityObject = api->godot_android_get_env()->NewGlobalRef(
-        api->godot_android_get_activity());
-    arvr_data->java.Env = api->godot_android_get_env();
-    api->godot_android_get_env()->GetJavaVM(&arvr_data->java.Vm);
+    arvr_data->java.ActivityObject = android_api->godot_android_get_env()->NewGlobalRef(
+        android_api->godot_android_get_activity());
+    arvr_data->java.Env = android_api->godot_android_get_env();
+    android_api->godot_android_get_env()->GetJavaVM(&arvr_data->java.Vm);
 
     for (int eye = 0; eye < EYE_NUM; eye++) {
       ovrFramebuffer_Clear(&arvr_data->frameBuffer[eye]);

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -1,23 +1,39 @@
 # Android.mk
 LOCAL_PATH := $(call my-dir)
-
 include $(CLEAR_VARS)
+
+# define some more paths
+# need to make some of these switchable
+# note also that godot_headers currently contains the headers for 3.0 so adjust this path to your 3.1 godot installation!
+# I am talking to Karroffel to get 3.1 headers in a branch so we can simply point our submodule to that branch
+SDK_PATH := $(LOCAL_PATH)/../../../ovr_sdk_mobile_1.9.0
+GODOT_HEADERS_PATH := $(LOCAL_PATH)/../godot_headers
+JDK_PATH := /Program Files/Java/jdk1.8.0_151
+
+# and configure our build
 LOCAL_MODULE := android_gdnative
 LOCAL_CPPFLAGS := -std=c++14
 LOCAL_CPP_FEATURES := rtti exceptions
-LOCAL_LDLIBS := -llog 
+LOCAL_LDLIBS := -llog
+
+APP_PLATFORM := android-18
+NDK_LIBS_OUT := $(LOCAL_PATH)/demo/addons/godot_gearvr/bin/
 
 LOCAL_SRC_FILES := \
 ARVRInterface.cpp godot_gearvr.cpp GodotCalls.cpp OS.cpp
 
-# VrApi libraries
-LOCAL_SRC_FILES := /home/paritosh97/Desktop/GearVR/oculus_mobile_vr/VrApi/Libs/Android/armeabi-v7a/Debug/
+# VrApi libraries (this breaks for me)
+LOCAL_STATIC_LIBRARIES := $(SDK_PATH)/VrApi/Libs/Android/armeabi-v7a/Debug/libvrapi.so
 
 # VrApi Headers
-LOCAL_EXPORT_C_INCLUDES := /home/paritosh97/Desktop/GearVR/oculus_mobile_vr/VrApi/Include/
+LOCAL_EXPORT_C_INCLUDES := $(SDK_PATH)/VrApi/Include/
 
 # gdnative and java headers
 LOCAL_C_INCLUDES := \
-/home/paritosh97/Desktop/Godot/godot/modules/gdnative/include /usr/local/java/jdk1.8.0_171/include /usr/local/java/jdk1.8.0_171/include/linux 
+. \
+$(GODOT_HEADERS_PATH) \
+$(SDK_PATH)/VrApi/Include/ \
+$(JDK_PATH)/include \
+$(JDK_PATH)/include/linux 
 
 include $(BUILD_SHARED_LIBRARY) 

--- a/jni/GodotCalls.cpp
+++ b/jni/GodotCalls.cpp
@@ -10,6 +10,7 @@
 
 const godot_gdnative_core_api_struct *api = NULL;
 const godot_gdnative_ext_arvr_api_struct *arvr_api = NULL;
+const godot_gdnative_ext_android_api_struct *android_api = NULL;
 const godot_gdnative_ext_nativescript_api_struct *nativescript_api = NULL;
 
 void GDN_EXPORT godot_gearvr_gdnative_init(godot_gdnative_init_options *p_options) {
@@ -23,6 +24,13 @@ void GDN_EXPORT godot_gearvr_gdnative_init(godot_gdnative_init_options *p_option
 			case GDNATIVE_EXT_ARVR: {
 				if (api->extensions[i]->version.major > 1 || (api->extensions[i]->version.major == 1 && api->extensions[i]->version.minor >= 1)) {
 					arvr_api = (godot_gdnative_ext_arvr_api_struct *)api->extensions[i];
+				} else {
+					printf("ARVR API version %i.%i isn't supported, need version 1.1 or higher\n", api->extensions[i]->version.major, api->extensions[i]->version.minor);
+				}
+			}; break;
+			case GDNATIVE_EXT_ANDROID: {
+				if (api->extensions[i]->version.major > 1 || (api->extensions[i]->version.major == 1 && api->extensions[i]->version.minor >= 0)) {
+					android_api = (godot_gdnative_ext_android_api_struct *)api->extensions[i];
 				} else {
 					printf("ARVR API version %i.%i isn't supported, need version 1.1 or higher\n", api->extensions[i]->version.major, api->extensions[i]->version.minor);
 				}

--- a/jni/GodotCalls.h
+++ b/jni/GodotCalls.h
@@ -47,6 +47,7 @@ typedef struct {
 // forward declarations
 extern const godot_gdnative_core_api_struct *api;
 extern const godot_gdnative_ext_arvr_api_struct *arvr_api;
+extern const godot_gdnative_ext_android_api_struct *android_api;
 extern const godot_gdnative_ext_nativescript_api_struct *nativescript_api;
 
 #ifdef __cplusplus


### PR DESCRIPTION
This changes the android API calls based on:
https://github.com/godotengine/godot/pull/19591

And made some additions to the makefile. Paths need much more improvement.
Hopefully we can soon link godot_headers to a branch that includes the 3.1 changes, I might just apply that on my own fork and link it to that for the time being.

Currently still having issues actually compiling, for some reason its not linking in the vrapi library. 